### PR TITLE
Add support for project specific configuration.

### DIFF
--- a/Uncrustify.sublime-settings
+++ b/Uncrustify.sublime-settings
@@ -1,20 +1,33 @@
 {
+  // All of these parameters may be supplied in a project settings file.
   // Specifies the path to uncrustify binary when not in the PATH.
   // For example:
   //	"uncrustify_executable" : "C:/UTILS/Devel/uncrustify/uncrustify.exe"
   "uncrustify_executable" : "",
 
-  // Specifies the config file for uncrustify when not set UNCRUSTIFY_CONFIG.
+  // Specifies the config file for uncrustify.  If not set, then the
+  // UNCRUSTIFY_CONFIG environment variable is used.  The configuration
+  // file name include '${project_dir}', which will be expanded to the
+  // directory name of the current project settings file.  This can help
+  // shared projects that include a project settings file (and an uncrustify
+  // configuration) in their SCM.  Additional environment variables are
+  // expanded into the stream, so you can use ${HOME} or whatever.
+  //
   // For example:
-  //	"uncrustify_config" : "C:/UTILS/Devel/uncrustify/cfg/defaults.cfg"
+  //	"uncrustify_config" : "${project_dir}/uncrustify.cfg"
+  // or
+  //    "uncrustify_config" : "${HOME}/.uncrustify"
+  //
   // NOTE:
-  //	You can copy the example config files in Uncrustify/etc (Source) or Uncrustify/cfg (Win32
-  //	pre-built) and modify as your version.
+  //	You can copy the example config files in Uncrustify/etc (Source) or
+  //    Uncrustify/cfg (Win32 pre-built) and modify as your version.
   "uncrustify_config" : "",
 
   // Overrides the default config (aka "uncrustify_config") when document matches one of below languages.
   // NOTE:
-  //	Don't use other language keywords which uncrustify don't supported.
+  //	Only those languages supported by uncrustify may be used here.  The
+  //    names used here are the names uncrustify gives to the language, and
+  //    must match.
   "uncrustify_config_by_lang" :
   [
 	// For example:
@@ -35,41 +48,47 @@
   ],
 
 
+  // These are for advanced users, who need to apply different styles
+  // for different folders or projects. (Note however that this package now
+  // supports project settings files, and those should be used instead.)
+  // These settings can be used within project files to provide more fine
+  // grained control though, for example a project that uses diferent
+  // styles for different subdirectories can use this.
 
-
-  // Belows are for advance users, who need to apply different styles according by projects, folders...
-
-  // Overrides the "uncrustify_config" and "uncrustify_config_by_lang" when path name of document matches
-  // one of below strings/patterns.
+  // Overrides the "uncrustify_config" and "uncrustify_config_by_lang" when
+  // the path name of document matches one of these strings or patterns.
   // NOTE:
-  //	1. The path name uses a forward slash character ("/") as its directory separator.
-  //	2. Comparing with the absolute path name of document not only the file name.
-  //	3. Please use a good string to avoid the incident match.
-  //	4. You can use "Open Uncrustify Config - Matches Current Document" in Uncrustify's Package Settings
-  //	   to test the matching.
+  //	1. The path name uses a forward slash character ("/") as its
+  //       directory separator.
+  //	2. The match is performed against the absolute path of the file
+  //       name, including the full directory.
+  //	3. You can use "Open Uncrustify Config - Matches Current Document"
+  //       in Uncrustify's Package Settings to test the matching.
   "uncrustify_config_by_filter" :
   [
 	// For example:
-	// All files in below folders use the custom configs, others use its language or default configs...
+	// All files in below folders use the custom configs, others use its
+	// language or default configs...
 	// { "D:/project/abc/libfoo" : "C:/cfg/foo.cfg" },
 	// { "D:/project/abc/src" : "C:/cfg/abc.cfg" }
   ],
 
   // When uses "uncrustify_config_by_filter", the folder matching rule is
-  //	0: Literal text, check if the string appeared inside as a subset. This is default.
-  //	   For example:
+  //	0: Literal text, check if the string appeared inside as a subset.
+  //       the This is default.  For example:
   //	   { "abc/src/" : "C:/cfg/abc.cfg" }
   //       for folders like D:/abc/src/, E:/xx/myabc/src/, ...
-  //	1: Unix wildcards, can use the special pattern characters *,?,[seq],[!seq]...
+  //	1: Unix filename globbing, can use the special pattern characters
+  //       *,?,[seq],[!seq]... (Also known as "wildcard characters").
   //	   For example:
-  //	   { "*[a]??/src/*" : "C:/cfg/abc.cfg" }
-  //       for folders likes D:/a12/src/, E:/xx/abc/src/, ... but not D:/b12/src/, D:/a123/src/, ...
+  //	   { "*foo/src/*" : "C:/cfg/abc.cfg" }
+  //       See file name globbing information.
   //	2: Regular expression, er... yah regular expression.
   //	   For example:
   //	   { ".*abc/src/.*" : "C:/cfg/abc.cfg" }
   // NOTE:
-  //	1. When uses rule 1 or 2, if the string without pattern characters means to compare to EQUAL!
-  //	   (not a subset string as rule 0)
+  //	1. When using rule 1 or 2, a string without pattern matching characters
+  //       must match exactly, (not a subset string as rule 0).
   //	2. All above rules are case sensitive!
   //	   (but rule 1 and 2 can be extended to case insensitive pattern)
   "uncrustify_filtering_rule" : 0
@@ -79,7 +98,10 @@
 //    https://en.wikipedia.org/wiki/Wildcard_character
 //    Examples:
 //	abc         ONLY 3 character name exactly.
-//	[abc]??     only 3 character name beginning with "a", "b", or "c".
-//	[1-9][A-Z]  only 2 character name starting with a number, and ending with an uppercase letter.
-//	[!A-Z]??    only 3 character name that does not begin with an uppercase letter.
+//	[abc]       only 3 character name beginning with "a", "b", or "c".
+//	[1-9][A-Z]  only 2 character name starting with a digit other than 0,
+//	            and ending with an uppercase letter.
+//	[!A-Z]      only 3 character name that does not begin with an
+//                  uppercase letter.
 //	*e[0-9]f    any file ending with "e", a single number, and "f".
+//      *.[ch]      any file name ending in .c or .h (e.g. C source files)


### PR DESCRIPTION
This allows Uncrustify to find configuration in project settings files,
allowing easier per-project configuration.  Configuration paths also have
two expansions on their names done.  The first is for ${project_dir},
which allows a project configuraiton to specify a relative path for the
configuration file.  The second is use of OS environment variable expansions,
allowing ${HOME} and such to be specified - making it easier to share these
configurations between users or across shared filesystems where paths may
differ on different systems.  (Think virtualization for example.)

While here I've updated the documentation in the sample configuration
to show these details, and to correct English language issues hopefully
making it clearer for some users.  (I'm a native English speaker -- it was
clear that the original author is not.)

As an aside, I *really* really hope this PR is accepted upstream; I maintain several other open source projects (some very widely used), with different coding styles, and this change is a huge improvement for me and my co-contributors.